### PR TITLE
ログインの uid がメールアドレスになってしまっているため更新するようパッチを当てる

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
     unless user.present?
       user = User.new(
         nickname: auth.info.name,
-        email: auth.info.email,
+        email: email,
         uid: uid,
         provider: provider
       )


### PR DESCRIPTION
users の uid が昔のものはメールアドレスになってしまっているため、sns_credentials テーブルを drop するときに更新を行う必要があった
それがなされていなかったため、随時更新するようパッチを当てる